### PR TITLE
test(emitter): assert off without handler

### DIFF
--- a/src/shared/emitter.test.js
+++ b/src/shared/emitter.test.js
@@ -76,7 +76,8 @@ describe('EventEmitter', function () {
 
   it('#off - noop (/wo handler)', function () {
     const emitter = new EventEmitter()
-    emitter.off('event', () => {})
+    assert.doesNotThrow(() => emitter.off('event', () => {}))
+    assert.strictEqual(emitter.emit('event'), false)
   })
 
   const errorCode = fn => R.tryCatch(fn, err => err.code)()


### PR DESCRIPTION
## Summary
- ensure `EventEmitter.off` without a handler does not throw and leaves emitter unchanged

## Testing
- `npm test` *(fails: src/renderer/model/selection/multiselect.test.js:338)*
- `node_modules/.bin/mocha src/shared/emitter.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689b34b859988330b5841a793a84643d