### PR TITLE
feat: make import async

### DIFF
--- a/src/renderer/store/Nominatim.js
+++ b/src/renderer/store/Nominatim.js
@@ -35,7 +35,7 @@ const Strategy = {
       ]
     })
 
-    store.import(removals.concat(additions))
+    await store.import(removals.concat(additions))
   },
 
   /**
@@ -43,7 +43,7 @@ const Strategy = {
    */
   sticky: store => async places => {
     const additions = places.map(([key, value]) => ({ type: 'put', key, value }))
-    store.import(additions.concat(additions))
+    await store.import(additions.concat(additions))
   }
 }
 
@@ -88,7 +88,7 @@ Nominatim.prototype.sync = async function (query) {
   }
 
   const places = response.map(R.compose(place, pretty))
-  this.strategy(places)
+  await this.strategy(places)
 }
 
 Nominatim.prototype.request = function (query) {

--- a/src/renderer/store/Store.js
+++ b/src/renderer/store/Store.js
@@ -238,8 +238,8 @@ Store.prototype.insert = function (tuples) {
 /**
  * import :: (operations, {k: v}) -> unit
  */
-Store.prototype.import = function (operations, options = {}) {
-  this.batch(this.db, operations, options)
+Store.prototype.import = async function (operations, options = {}) {
+  await this.batch(this.db, operations, options)
 }
 
 


### PR DESCRIPTION
## Summary
- Make `Store.prototype.import` asynchronous and await underlying batch writes
- Ensure Nominatim strategies and sync method await the import operations

## Testing
- `npm test` *(fails: multiselect click meta toggle selection)*
- `npm run lint` *(fails: 25 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_689b34a4f5f483309e945802706f4e33