### PR TITLE
Link symbol property preference to modifier updates

### DIFF
--- a/src/renderer/ol/style/symbol.js
+++ b/src/renderer/ol/style/symbol.js
@@ -6,18 +6,26 @@ import { MODIFIERS } from '../../symbology/2525c'
  *
  */
 export default $ => {
-  $.shape = $.properties.map(properties => {
-    const sidc = properties.sidc
-    const modifiers = Object.entries(properties)
-      .filter(([key, value]) => MODIFIERS[key] && value)
-      .reduce((acc, [key, value]) => R.tap(acc => (acc[MODIFIERS[key]] = value), acc), {})
+  $.shape = Signal.link(
+    (properties, show) => {
+      const sidc = properties.sidc
+      const modifiers = show
+        ? Object.entries(properties)
+            .filter(([key, value]) => MODIFIERS[key] && value)
+            .reduce((acc, [key, value]) => {
+              acc[MODIFIERS[key]] = value
+              return acc
+            }, {})
+        : {}
 
-    return [{
-      id: 'style:2525c/symbol',
-      'symbol-code': sidc,
-      'symbol-modifiers': modifiers
-    }]
-  }, [])
+      return [{
+        id: 'style:2525c/symbol',
+        'symbol-code': sidc,
+        'symbol-modifiers': modifiers
+      }]
+    },
+    [$.properties, $.symbolPropertiesShowing]
+  )
 
   $.selection = $.selectionMode.map(mode =>
     mode === 'multiselect'

--- a/src/renderer/ol/style/symbol.test.js
+++ b/src/renderer/ol/style/symbol.test.js
@@ -1,0 +1,34 @@
+import assert from 'assert'
+import * as R from 'ramda'
+import Signal from '@syncpoint/signal'
+
+import symbol from './symbol'
+
+describe('symbol style', () => {
+  it('updates modifiers when preference toggles', () => {
+    const properties = Signal.of({ sidc: 'SFGPUCI----', t: 'A' })
+    const show = Signal.of(true)
+    const selectionMode = Signal.of('single')
+    const styleRegistry = Signal.of(R.identity)
+    const styleFactory = Signal.of(R.identity)
+
+    const $ = { properties, symbolPropertiesShowing: show, selectionMode, styleRegistry, styleFactory }
+    symbol($)
+
+    const shapes = []
+    $.shape.on(s => shapes.push(s))
+
+    assert.strictEqual(shapes.length, 1)
+    assert.deepStrictEqual(shapes[0][0]['symbol-modifiers'], { uniqueDesignation: 'A' })
+
+    show(false)
+    assert.strictEqual(shapes.length, 2)
+    assert.deepStrictEqual(shapes[1][0]['symbol-modifiers'], {})
+
+    show(true)
+    assert.strictEqual(shapes.length, 3)
+    assert.deepStrictEqual(shapes[2][0]['symbol-modifiers'], { uniqueDesignation: 'A' })
+    assert(shapes.every(s => s.length === 1 && s[0].id === 'style:2525c/symbol'))
+  })
+})
+


### PR DESCRIPTION
## Summary
- recompute symbol modifiers when symbol properties or preference change
- add regression test ensuring preference toggle updates modifiers without recreating layer

## Testing
- `npm test`
- `npm run lint` *(fails: featureStore assigned but never used, Roboto-Medium BOM, User prop-types, ReplicationCommands role unused, 2525c.js unnecessary return)*

------
https://chatgpt.com/codex/tasks/task_e_689b412d7cb48330bc71309bce890c66