### PR TITLE
feat: add symbol properties preference toggle

### DIFF
--- a/src/main/menu/view-menu.js
+++ b/src/main/menu/view-menu.js
@@ -6,6 +6,7 @@ export default options => {
   const graticule = preferences.graticule
   const sidebarShowing = preferences['ui.sidebar.showing'] ?? true
   const toolbarShowing = preferences['ui.toolbar.showing'] ?? true
+  const symbolPropertiesShowing = preferences['ui.symbolProperties.showing'] ?? true
 
   return [{
     label: 'View',
@@ -93,6 +94,14 @@ export default options => {
             checked: toolbarShowing,
             click: ({ checked }, browserWindow) => {
               if (browserWindow) browserWindow.webContents.send('VIEW_SHOW_TOOLBAR', checked)
+            }
+          },
+          {
+            label: 'Show Symbol Properties',
+            type: 'checkbox',
+            checked: symbolPropertiesShowing,
+            click: ({ checked }, browserWindow) => {
+              if (browserWindow) browserWindow.webContents.send('VIEW_SHOW_SYMBOL_PROPERTIES', checked)
             }
           }
         ]

--- a/src/renderer/components/map/Map.js
+++ b/src/renderer/components/map/Map.js
@@ -31,7 +31,7 @@ export const Map = () => {
     const key = 'ui.symbolProperties.showing'
 
     ;(async () => {
-      const showing = await services.preferencesStore.get(key, true)
+      const showing = await services.preferencesStore.getSymbolPropertiesShowing()
       symbolPropertiesShowing(showing)
     })()
 

--- a/src/renderer/store/PreferencesStore.js
+++ b/src/renderer/store/PreferencesStore.js
@@ -5,6 +5,7 @@ import * as L from '../../shared/level'
 const COORDINATES_FORMAT = 'coordinates-format'
 const GRATICULE = 'graticule'
 const TILE_LAYERS = 'tile-layers'
+const SYMBOL_PROPERTIES_SHOWING = 'ui.symbolProperties.showing'
 
 export default function PreferencesStore (preferencesDB, ipcRenderer) {
   Emitter.call(this)
@@ -30,6 +31,7 @@ export default function PreferencesStore (preferencesDB, ipcRenderer) {
   ipcRenderer.on('VIEW_GRATICULE', (_, type, checked) => this.setGraticule(type, checked))
   ipcRenderer.on('VIEW_SHOW_SIDEBAR', (_, checked) => this.showSidebar(checked))
   ipcRenderer.on('VIEW_SHOW_TOOLBAR', (_, checked) => this.showToolbar(checked))
+  ipcRenderer.on('VIEW_SHOW_SYMBOL_PROPERTIES', (_, checked) => this.showSymbolProperties(checked))
 }
 
 util.inherits(PreferencesStore, Emitter)
@@ -51,6 +53,14 @@ PreferencesStore.prototype.showSidebar = function (checked) {
 
 PreferencesStore.prototype.showToolbar = function (checked) {
   this.put('ui.toolbar.showing', checked)
+}
+
+PreferencesStore.prototype.showSymbolProperties = function (checked) {
+  this.put(SYMBOL_PROPERTIES_SHOWING, checked)
+}
+
+PreferencesStore.prototype.getSymbolPropertiesShowing = function () {
+  return this.get(SYMBOL_PROPERTIES_SHOWING, true)
 }
 
 /**


### PR DESCRIPTION
## Summary
- support a persisted `ui.symbolProperties.showing` preference
- expose "Show Symbol Properties" checkbox in the View menu
- use new getter in Map component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b4c6972208330b49e33c2b6c8f081