### PR TITLE
Listen for symbol properties toggle

### DIFF
--- a/src/main/menu/view-menu.js
+++ b/src/main/menu/view-menu.js
@@ -101,7 +101,7 @@ export default options => {
             type: 'checkbox',
             checked: symbolPropertiesShowing,
             click: ({ checked }, browserWindow) => {
-              if (browserWindow) browserWindow.webContents.send('VIEW_SHOW_SYMBOL_PROPERTIES', checked)
+              if (browserWindow) browserWindow.webContents.send('VIEW_SYMBOL_PROPERTIES', checked)
             }
           }
         ]

--- a/src/main/menu/view-menu.test.js
+++ b/src/main/menu/view-menu.test.js
@@ -1,0 +1,26 @@
+import assert from 'assert'
+import viewMenu from './view-menu.js'
+
+describe('view-menu symbol properties item', () => {
+  const findSymbolItem = (prefs = {}) => {
+    const menu = viewMenu({ preferences: prefs })[0]
+    const appearance = menu.submenu.find(item => item.label === 'Appearance')
+    return appearance.submenu.find(item => item.label === 'Show Symbol Properties')
+  }
+
+  it('reflects preference state', () => {
+    const unchecked = findSymbolItem({ 'ui.symbolProperties.showing': false })
+    assert.strictEqual(unchecked.checked, false)
+
+    const checked = findSymbolItem({ 'ui.symbolProperties.showing': true })
+    assert.strictEqual(checked.checked, true)
+  })
+
+  it('sends VIEW_SYMBOL_PROPERTIES on click', () => {
+    const item = findSymbolItem()
+    let sent
+    const browserWindow = { webContents: { send: (...args) => { sent = args } } }
+    item.click({ checked: false }, browserWindow)
+    assert.deepStrictEqual(sent, ['VIEW_SYMBOL_PROPERTIES', false])
+  })
+})

--- a/src/renderer/store/PreferencesStore.js
+++ b/src/renderer/store/PreferencesStore.js
@@ -31,7 +31,7 @@ export default function PreferencesStore (preferencesDB, ipcRenderer) {
   ipcRenderer.on('VIEW_GRATICULE', (_, type, checked) => this.setGraticule(type, checked))
   ipcRenderer.on('VIEW_SHOW_SIDEBAR', (_, checked) => this.showSidebar(checked))
   ipcRenderer.on('VIEW_SHOW_TOOLBAR', (_, checked) => this.showToolbar(checked))
-  ipcRenderer.on('VIEW_SHOW_SYMBOL_PROPERTIES', (_, checked) => this.showSymbolProperties(checked))
+  ipcRenderer.on('VIEW_SYMBOL_PROPERTIES', (_, checked) => this.showSymbolProperties(checked))
 }
 
 util.inherits(PreferencesStore, Emitter)


### PR DESCRIPTION
## Summary
- handle `VIEW_SYMBOL_PROPERTIES` in renderer preferences
- wire view menu "Show Symbol Properties" to `VIEW_SYMBOL_PROPERTIES`
- test that view menu checkbox mirrors preferences and sends toggle event

## Testing
- `npm test`
- `npm run lint` *(fails: 'featureStore' is assigned a value but never used, and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b557a93d483309f6ef1245b5a50a3