### PR TITLE
Refactor Map initialization effect for proper cleanup

### DIFF
--- a/src/renderer/components/map/Map.js
+++ b/src/renderer/components/map/Map.js
@@ -15,6 +15,7 @@ import registerEventHandlers from './eventHandlers'
 import registerGraticules from './graticules'
 import measure from '../../ol/interaction/measure'
 import print from '../print'
+import mapEffect from './effect'
 import './Map.css'
 import './ScaleLine.css'
 
@@ -41,53 +42,26 @@ export const Map = () => {
     return () => services.preferencesStore.off(key, handle)
   }, [services.preferencesStore, symbolPropertiesShowing])
 
-  React.useEffect(() => {
-    let map
+  const effect = mapEffect({
+    services,
+    ref,
+    symbolPropertiesShowing,
+    ol,
+    ScaleLine,
+    Rotate,
+    defaultInteractions,
+    vectorSources,
+    createMapView,
+    createLayerStyles,
+    createVectorLayers,
+    createTileLayers,
+    registerEventHandlers,
+    registerGraticules,
+    measure,
+    print
+  })
 
-    ;(async () => {
-      const view = await createMapView(services)
-      const sources = await vectorSources({ ...services, symbolPropertiesShowing })
-      const styles = createLayerStyles(services, sources)
-      const vectorLayers = createVectorLayers(sources, styles)
-
-      const controlsTarget = document.getElementById('osd')
-      const controls = [
-        new Rotate({ target: controlsTarget }), // macOS: OPTION + SHIFT + DRAG
-        new ScaleLine({ bar: true, text: true, minWidth: 128, target: controlsTarget })
-      ]
-
-      const tileLayers = await createTileLayers(services)
-      const layers = [...tileLayers, ...Object.values(vectorLayers)]
-
-      map = new ol.Map({
-        target: 'map',
-        controls,
-        layers,
-        view,
-        interactions: []
-      })
-
-      defaultInteractions({
-        hitTolerance: 3,
-        map,
-        services,
-        sources,
-        styles
-      })
-
-      registerEventHandlers({ services, sources, vectorLayers, map })
-      registerGraticules({ services, map })
-      print({ map, services })
-
-      // Force map resize on container resize:
-      const observer = new ResizeObserver(() => map.updateSize())
-      observer.observe(ref.current)
-
-      measure({ services, map })
-    })()
-
-    return () => map && map.dispose()
-  }, [])
+  React.useEffect(() => effect(), [])
 
   return <div
     id='map'

--- a/src/renderer/components/map/effect.js
+++ b/src/renderer/components/map/effect.js
@@ -1,0 +1,72 @@
+export default options => {
+  const {
+    services,
+    ref,
+    symbolPropertiesShowing,
+    ol,
+    ScaleLine,
+    Rotate,
+    defaultInteractions,
+    vectorSources,
+    createMapView,
+    createLayerStyles,
+    createVectorLayers,
+    createTileLayers,
+    registerEventHandlers,
+    registerGraticules,
+    measure,
+    print
+  } = options
+
+  return () => {
+    let map
+    let observer
+
+    ;(async () => {
+      const view = await createMapView(services)
+      const sources = await vectorSources({ ...services, symbolPropertiesShowing })
+      const styles = createLayerStyles(services, sources)
+      const vectorLayers = createVectorLayers(sources, styles)
+
+      const controlsTarget = document.getElementById('osd')
+      const controls = [
+        new Rotate({ target: controlsTarget }),
+        new ScaleLine({ bar: true, text: true, minWidth: 128, target: controlsTarget })
+      ]
+
+      const tileLayers = await createTileLayers(services)
+      const layers = [...tileLayers, ...Object.values(vectorLayers)]
+
+      map = new ol.Map({
+        target: 'map',
+        controls,
+        layers,
+        view,
+        interactions: []
+      })
+
+      defaultInteractions({
+        hitTolerance: 3,
+        map,
+        services,
+        sources,
+        styles
+      })
+
+      registerEventHandlers({ services, sources, vectorLayers, map })
+      registerGraticules({ services, map })
+      print({ map, services })
+
+      observer = new ResizeObserver(() => map.updateSize())
+      observer.observe(ref.current)
+
+      measure({ services, map })
+    })()
+
+    return () => {
+      if (observer) observer.disconnect()
+      if (map) map.dispose()
+    }
+  }
+}
+

--- a/src/renderer/components/map/effect.test.js
+++ b/src/renderer/components/map/effect.test.js
@@ -1,0 +1,52 @@
+import assert from 'assert'
+import effect from './effect'
+
+describe('map effect', () => {
+  it('disconnects observer and disposes map on cleanup', async function () {
+    let disposed = false
+    const map = {
+      dispose: () => { disposed = true },
+      updateSize: () => {}
+    }
+
+    let disconnected = false
+    const OriginalRO = global.ResizeObserver
+    const OriginalDoc = global.document
+    class RO {
+      constructor () {}
+      observe () {}
+      disconnect () { disconnected = true }
+    }
+    global.ResizeObserver = RO
+    global.document = { getElementById: () => ({}) }
+
+    const init = effect({
+      services: {},
+      ref: { current: {} },
+      symbolPropertiesShowing: () => {},
+      ol: { Map: function () { return map } },
+      ScaleLine: function () {},
+      Rotate: function () {},
+      defaultInteractions: () => {},
+      vectorSources: async () => ({}),
+      createMapView: async () => ({}),
+      createLayerStyles: () => ({}),
+      createVectorLayers: () => ({}),
+      createTileLayers: async () => ([]),
+      registerEventHandlers: () => {},
+      registerGraticules: () => {},
+      measure: () => {},
+      print: () => {}
+    })
+
+    const cleanup = init()
+    await new Promise(resolve => setImmediate(resolve))
+    cleanup()
+    global.ResizeObserver = OriginalRO
+    global.document = OriginalDoc
+
+    assert.ok(disposed)
+    assert.ok(disconnected)
+  })
+})
+


### PR DESCRIPTION
## Summary
- Refactor `Map` component to use a dedicated initialization effect with standard cleanup
- Add effect module to initialize map and release ResizeObserver and map resources
- Test that mounting/unmounting Map cleans up observers and disposes map

## Testing
- `npm test`
- `npm run lint` *(fails: no-unused-vars, unicode-bom, prop-types, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689c971b915883308113298a4366a534