### PR TITLE
Optimize symbol style updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ Copyright (c) Syncpoint GmbH. All rights reserved.
 Licensed under the [GNU Affero GPL v3](LICENSE.md) License.
 
 When using the ODIN or other GitHub logos, be sure to follow the [GitHub logo guidelines](https://github.com/logos).
+
+## Performance
+
+Recent updates improve rendering performance on large maps by caching symbol style modifiers and reusing style instances. Style updates are throttled using a circuit breaker to avoid excessive recomputation when text visibility is toggled rapidly.

--- a/src/renderer/ol/style/symbol.js
+++ b/src/renderer/ol/style/symbol.js
@@ -1,28 +1,44 @@
 import * as R from 'ramda'
 import Signal from '@syncpoint/signal'
+import { circuitBreaker } from '../../../shared/signal'
 import { MODIFIERS } from '../../symbology/2525c'
 
 /**
  *
  */
+const modifierCache = new WeakMap()
+const styleCache = new Map()
+
+const computeModifiers = properties => {
+  if (modifierCache.has(properties)) return modifierCache.get(properties)
+  const modifiers = Object.entries(properties)
+    .filter(([key, value]) => MODIFIERS[key] && value)
+    .reduce((acc, [key, value]) => {
+      acc[MODIFIERS[key]] = value
+      return acc
+    }, {})
+  modifierCache.set(properties, modifiers)
+  return modifiers
+}
+
+const getStyle = (sidc, modifiers) => {
+  const key = `${sidc}-${JSON.stringify(modifiers)}`
+  if (styleCache.has(key)) return styleCache.get(key)
+  const style = [{
+    id: 'style:2525c/symbol',
+    'symbol-code': sidc,
+    'symbol-modifiers': modifiers
+  }]
+  styleCache.set(key, style)
+  return style
+}
+
 export default $ => {
   $.shape = Signal.link(
     (properties, show) => {
       const sidc = properties.sidc
-      const modifiers = show
-        ? Object.entries(properties)
-            .filter(([key, value]) => MODIFIERS[key] && value)
-            .reduce((acc, [key, value]) => {
-              acc[MODIFIERS[key]] = value
-              return acc
-            }, {})
-        : {}
-
-      return [{
-        id: 'style:2525c/symbol',
-        'symbol-code': sidc,
-        'symbol-modifiers': modifiers
-      }]
+      const modifiers = show ? computeModifiers(properties) : {}
+      return getStyle(sidc, modifiers)
     },
     [$.properties, $.symbolPropertiesShowing]
   )
@@ -33,13 +49,15 @@ export default $ => {
       : []
   )
 
-  $.styles = Signal.link(
+  const combined = Signal.link(
     (...styles) => styles.reduce(R.concat),
     [
       $.shape,
       $.selection
     ]
   )
+
+  $.styles = circuitBreaker(combined).filter(Boolean)
 
   return $.styles
     .ap($.styleRegistry)

--- a/src/renderer/ol/style/symbol.test.js
+++ b/src/renderer/ol/style/symbol.test.js
@@ -29,6 +29,27 @@ describe('symbol style', () => {
     assert.strictEqual(shapes.length, 3)
     assert.deepStrictEqual(shapes[2][0]['symbol-modifiers'], { uniqueDesignation: 'A' })
     assert(shapes.every(s => s.length === 1 && s[0].id === 'style:2525c/symbol'))
+    assert.strictEqual(shapes[0], shapes[2])
+  })
+
+  it('throttles rapid style updates', () => {
+    const properties = Signal.of({ sidc: 'SFGPUCI----', t: 'A' })
+    const show = Signal.of(true)
+    const selectionMode = Signal.of('single')
+    const styleRegistry = Signal.of(R.identity)
+    const styleFactory = Signal.of(R.identity)
+
+    const $ = { properties, symbolPropertiesShowing: show, selectionMode, styleRegistry, styleFactory }
+    symbol($)
+
+    const styles = []
+    $.styles.on(s => styles.push(s))
+
+    for (let i = 0; i < 25; i++) {
+      show(i % 2 === 1)
+    }
+
+    assert(styles.length <= 11)
   })
 })
 


### PR DESCRIPTION
## Summary
- cache computed symbol modifiers and reuse style arrays to avoid redundant work
- throttle symbol style recomputation with `circuitBreaker`
- document performance improvements and add tests for caching and throttling

## Testing
- `npm test`
- `npm run lint` *(fails: 9 errors, 2 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_689c9d03288883308a93e7b71393b215