### PR TITLE
feat: add replication seed retrieval

### DIFF
--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -67,6 +67,20 @@ export const ipc = (databases, ipcMain, projectStore) => {
     return projectStore.delCredentials(id)
   })
 
+  ipcMain.handle('ipc:get:project:replication/seed', async (_, id) => {
+    try {
+      const uuid = id.split(':')[1]
+      const location = path.join(databases, uuid)
+      const db = leveldb({ location })
+      const session = sessionDB(db)
+      const seed = await session.get('replication:seed').catch(() => null)
+      await db.close()
+      return seed
+    } catch (error) {
+      console.error(error)
+    }
+  })
+
   ipcMain.handle('ipc:put:project:replication/seed', async (_, id, seed) => {
     try {
       const uuid = id.split(':')[1]

--- a/src/renderer/store/ProjectStore.js
+++ b/src/renderer/store/ProjectStore.js
@@ -166,6 +166,10 @@ ProjectStore.prototype.delCredentials = async function (id) {
   return this.ipcRenderer.invoke('ipc:del:replication/credentials', id)
 }
 
+ProjectStore.prototype.getReplicationSeed = async function (id) {
+  return this.ipcRenderer.invoke('ipc:get:project:replication/seed', id)
+}
+
 ProjectStore.prototype.putReplicationSeed = async function (id, seed) {
   return this.ipcRenderer.invoke('ipc:put:project:replication/seed', id, seed)
 }


### PR DESCRIPTION
## Summary
- expose `getReplicationSeed` via renderer `ProjectStore`
- add IPC handler to fetch replication seed from a project's session database

## Testing
- `npm test`
- `npm run lint` *(fails: featureStore is assigned a value but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a4924cf90c8330b96dd467efee784d